### PR TITLE
Update to work hydra 1.2 and up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         # '3.10' is failing because of deprecation
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: ["3.10", 3.11]
     env:
       PLATFORM: ${{ matrix.platform }}
     steps:

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -6,7 +6,7 @@ hydra:
   # the defaults can make overlapping folders
   sweep:
     dir: multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
-    subdir: ${hydra.sweeper.orion.name}/${hydra.sweeper.orion.uuid}/${hydra.job.id}
+    subdir: ${hydra.sweeper.experiment.name}/${hydra.sweeper.experiment.uuid}/${hydra.job.id}
 
   sweeper:
     # default parametrization of the search space

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -18,7 +18,7 @@ hydra:
       batch_size: "uniform(4, 16, discrete=True)"
       epoch: "fidelity(10, 100)"
 
-    orion:
+    experiment:
       name: 'experiment'
       version: '1'
 

--- a/example/my_app.py
+++ b/example/my_app.py
@@ -8,7 +8,7 @@ import sys
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path=".", config_name="config", version_base="1.2")
+@hydra.main(config_path=".", config_name="config", version_base=None)
 def dummy_training(cfg: DictConfig) -> float:
     """A dummy function to minimize
     Minimum is 0.0 at:

--- a/example/my_app.py
+++ b/example/my_app.py
@@ -8,7 +8,7 @@ import sys
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path=".", config_name="config", version_base="1.1")
+@hydra.main(config_path=".", config_name="config", version_base="1.2")
 def dummy_training(cfg: DictConfig) -> float:
     """A dummy function to minimize
     Minimum is 0.0 at:

--- a/example/my_app.py
+++ b/example/my_app.py
@@ -15,9 +15,6 @@ def dummy_training(cfg: DictConfig) -> float:
     lr = 0.12, dropout=0.33, opt=Adam, batch_size=4
     """
     
-    # makes sure folders are unique
-    os.makedirs('newdir', exist_ok=False)
-    
     do = cfg.dropout
     bs = cfg.batch_size
     out = float(

--- a/hydra_plugins/hydra_orion_sweeper/__init__.py
+++ b/hydra_plugins/hydra_orion_sweeper/__init__.py
@@ -1,5 +1,5 @@
 """Plugin metadata"""
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __descr__ = "Hydra Sweeper Plugin for Orion"
 __license__ = "BSD-3-Clause"
 __author__ = "Epistímio"

--- a/hydra_plugins/hydra_orion_sweeper/config.py
+++ b/hydra_plugins/hydra_orion_sweeper/config.py
@@ -82,7 +82,9 @@ class OrionSweeperConf:
 
     _target_: str = "hydra_plugins.hydra_orion_sweeper.orion_sweeper.OrionSweeper"
 
-    orion: OrionClientConf = field(default_factory=OrionClientConf)
+    orion: Optional[OrionClientConf] = field(default_factory=OrionClientConf)
+
+    experiment: Optional[OrionClientConf] = field(default_factory=OrionClientConf)
 
     worker: WorkerConf = field(default_factory=WorkerConf)
 

--- a/hydra_plugins/hydra_orion_sweeper/config.py
+++ b/hydra_plugins/hydra_orion_sweeper/config.py
@@ -82,9 +82,7 @@ class OrionSweeperConf:
 
     _target_: str = "hydra_plugins.hydra_orion_sweeper.orion_sweeper.OrionSweeper"
 
-    orion: Optional[OrionClientConf] = field(default_factory=OrionClientConf)
-
-    experiment: Optional[OrionClientConf] = field(default_factory=OrionClientConf)
+    experiment: OrionClientConf = field(default_factory=OrionClientConf)
 
     worker: WorkerConf = field(default_factory=WorkerConf)
 

--- a/hydra_plugins/hydra_orion_sweeper/config.py
+++ b/hydra_plugins/hydra_orion_sweeper/config.py
@@ -91,11 +91,11 @@ class OrionSweeperConf:
     storage: StorageConf = field(default_factory=StorageConf)
 
     # deprecated, use params instead
-    parametrization: Optional[Dict[str, Any]] = None
+    parametrization: Optional[Dict[str, Any]] = field(default_factory=dict)
 
     # Search space (Optuna & default)
     # See `Search Space <https://orion.readthedocs.io/en/stable/user/searchspace.html>`_
-    params: Optional[Dict[str, Any]] = None
+    params: Optional[Dict[str, Any]] = field(default_factory=dict)
 
     # Note: Ax space is configured as hydra.sweeper.ax.ax_config.params
     # which is a bit too convoluted for us to support

--- a/hydra_plugins/hydra_orion_sweeper/implementation.py
+++ b/hydra_plugins/hydra_orion_sweeper/implementation.py
@@ -591,7 +591,7 @@ class OrionSweeperImpl(Sweeper):
         results["best_evaluated_params"] = best_params
         results["start_time"] = str(results["start_time"])
         results["finish_time"] = str(results["finish_time"])
-        results["duration"] = str(results.get("duration", 0))
+        results["elapsed_time"] = str(results.get("elapsed_time", 0))
 
         OmegaConf.save(
             OmegaConf.create(results),

--- a/hydra_plugins/hydra_orion_sweeper/implementation.py
+++ b/hydra_plugins/hydra_orion_sweeper/implementation.py
@@ -166,9 +166,9 @@ def as_overrides(trial, additional, uuid):
 
     args = [f"{k}={v}" for k, v in kwargs.items()]
     args += [
-        f"hydra.sweeper.orion.id={trial.experiment}",
-        f"hydra.sweeper.orion.trial={trial.id}",
-        f"hydra.sweeper.orion.uuid={uuid}",
+        f"hydra.sweeper.experiment.id={trial.experiment}",
+        f"hydra.sweeper.experiment.trial={trial.id}",
+        f"hydra.sweeper.experiment.uuid={uuid}",
     ]
     return tuple(args)
 
@@ -338,7 +338,7 @@ class OrionSweeperImpl(Sweeper):
 
     def __init__(
         self,
-        orion: OrionClientConf,
+        experiment: OrionClientConf,
         worker: WorkerConf,
         algorithm: AlgorithmConf,
         storage: StorageConf,
@@ -351,7 +351,7 @@ class OrionSweeperImpl(Sweeper):
         self.storage = None
         self.uuid = uuid.uuid1().hex
 
-        self.orion_config = orion
+        self.orion_config = experiment
         self.worker_config = worker
         self.algo_config = algorithm
         self.storage_config = storage

--- a/hydra_plugins/hydra_orion_sweeper/implementation.py
+++ b/hydra_plugins/hydra_orion_sweeper/implementation.py
@@ -591,7 +591,7 @@ class OrionSweeperImpl(Sweeper):
         results["best_evaluated_params"] = best_params
         results["start_time"] = str(results["start_time"])
         results["finish_time"] = str(results["finish_time"])
-        results["duration"] = str(results["duration"])
+        results["duration"] = str(results.get("duration", 0))
 
         OmegaConf.save(
             OmegaConf.create(results),

--- a/hydra_plugins/hydra_orion_sweeper/implementation.py
+++ b/hydra_plugins/hydra_orion_sweeper/implementation.py
@@ -585,13 +585,16 @@ class OrionSweeperImpl(Sweeper):
         results = self.client.stats
 
         best_params = self.client.get_trial(uid=results.best_trials_id).params
-
+            
+        print(results)
         results = asdict(results)
         results["name"] = "orion"
         results["best_evaluated_params"] = best_params
         results["start_time"] = str(results["start_time"])
         results["finish_time"] = str(results["finish_time"])
         results["elapsed_time"] = str(results.get("elapsed_time", 0))
+        results["sum_of_trials_time"] = str(results.get("sum_of_trials_time", 0))
+        results["eta"] = str(results.get("eta", 0))
 
         OmegaConf.save(
             OmegaConf.create(results),

--- a/hydra_plugins/hydra_orion_sweeper/implementation.py
+++ b/hydra_plugins/hydra_orion_sweeper/implementation.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 NESTED_DIM_REGEX = re.compile(r"[A-Za-z0-9]*(\.[A-Za-z0-9]*)+=.*")
 
+
 # pylint: disable=too-few-public-methods
 class SpaceFunction:
     """Type to recognize orion functions parsed by the override parser"""
@@ -585,7 +586,7 @@ class OrionSweeperImpl(Sweeper):
         results = self.client.stats
 
         best_params = self.client.get_trial(uid=results.best_trials_id).params
-            
+
         print(results)
         results = asdict(results)
         results["name"] = "orion"

--- a/hydra_plugins/hydra_orion_sweeper/orion_sweeper.py
+++ b/hydra_plugins/hydra_orion_sweeper/orion_sweeper.py
@@ -18,7 +18,6 @@ class OrionSweeper(Sweeper):
 
     def __init__(
         self,
-        orion: Optional[OrionClientConf],
         experiment: Optional[OrionClientConf],
         worker: WorkerConf,
         algorithm: AlgorithmConf,
@@ -27,22 +26,6 @@ class OrionSweeper(Sweeper):
         params: Optional[DictConfig],
     ):
         from .implementation import OrionSweeperImpl
-
-        if orion is not None and experiment is not None:
-            warn(
-                "`hydra.sweeper.orion` is deprecated;"
-                "move the values to experiment"
-                "`hydra.sweeper.orion` are ignored",
-                DeprecationWarning,
-            )
-
-        if orion is not None and experiment is None:
-            warn(
-                "`hydra.sweeper.orion` is deprecated;"
-                "use `hydra.sweeper.experiment` instead",
-                DeprecationWarning,
-            )
-            experiment = orion
 
         # >>> Remove with Issue #8
         if parametrization is not None and params is None:

--- a/hydra_plugins/hydra_orion_sweeper/orion_sweeper.py
+++ b/hydra_plugins/hydra_orion_sweeper/orion_sweeper.py
@@ -18,7 +18,8 @@ class OrionSweeper(Sweeper):
 
     def __init__(
         self,
-        orion: OrionClientConf,
+        orion: Optional[OrionClientConf],
+        experiment: Optional[OrionClientConf],
         worker: WorkerConf,
         algorithm: AlgorithmConf,
         storage: StorageConf,
@@ -27,10 +28,26 @@ class OrionSweeper(Sweeper):
     ):
         from .implementation import OrionSweeperImpl
 
+        if orion is not None and experiment is not None:
+            warn(
+                "`hydra.sweeper.orion` is deprecated;"
+                "move the values to experiment"
+                "`hydra.sweeper.orion` are ignored",
+                DeprecationWarning,
+            )
+
+        if orion is not None and experiment is None:
+            warn(
+                "`hydra.sweeper.orion` is deprecated;"
+                "use `hydra.sweeper.experiment` instead",
+                DeprecationWarning,
+            )
+            experiment = orion
+
         # >>> Remove with Issue #8
         if parametrization is not None and params is None:
             warn(
-                "`hydra.sweeper.orion.parametrization` is deprecated;"
+                "`hydra.sweeper.parametrization` is deprecated;"
                 "use `hydra.sweeper.params` instead",
                 DeprecationWarning,
             )
@@ -38,7 +55,7 @@ class OrionSweeper(Sweeper):
 
         elif parametrization is not None and params is not None:
             warn(
-                "Both `hydra.sweeper.orion.parametrization` and `hydra.sweeper.params` are defined;"
+                "Both `hydra.sweeper.parametrization` and `hydra.sweeper.params` are defined;"
                 "using `hydra.sweeper.params`",
                 DeprecationWarning,
             )
@@ -47,7 +64,7 @@ class OrionSweeper(Sweeper):
         if params is None:
             params = dict()
 
-        self.sweeper = OrionSweeperImpl(orion, worker, algorithm, storage, params)
+        self.sweeper = OrionSweeperImpl(experiment, worker, algorithm, storage, params)
 
     def setup(
         self,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     install_requires=[
         'typing_extensions',
-        "hydra-core>=1.2",
+        "hydra-core==1.2",
         "orion>=0.2.2",
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,9 @@ setup(
     ],
     install_requires=[
         'typing_extensions',
-        "hydra-core==1.2",
+        "hydra-core<=1.2",
         "orion>=0.2.2",
+        "omegaconf~=2.2",
     ],
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ setup(
     ],
     install_requires=[
         'typing_extensions',
-        "hydra-core<=1.2",
+        "hydra-core",
         "orion>=0.2.2",
-        "omegaconf~=2.2",
+        "omegaconf",
     ],
     include_package_data=True,
 )

--- a/tests/hydra_config.py
+++ b/tests/hydra_config.py
@@ -7,7 +7,7 @@
         },
         "sweeper": {
             "_target_": "hydra_plugins.hydra_orion_sweeper.orion_sweeper.OrionSweeper",
-            "orion": {
+            "experiment": {
                 "name": None,
                 "version": None,
                 "branching": None,

--- a/tests/test_orion.py
+++ b/tests/test_orion.py
@@ -42,8 +42,7 @@ def load_hydra_testing_config():
 
 def orion_configuration():
     return dict(
-        orion=OmegaConf.structured(OrionClientConf()),
-        experiment=None,
+        experiment=OmegaConf.structured(OrionClientConf()),
         worker=OmegaConf.structured(WorkerConf()),
         algorithm=OmegaConf.structured(AlgorithmConf()),
         storage=OmegaConf.structured(StorageConf()),

--- a/tests/test_orion.py
+++ b/tests/test_orion.py
@@ -43,6 +43,7 @@ def load_hydra_testing_config():
 def orion_configuration():
     return dict(
         orion=OmegaConf.structured(OrionClientConf()),
+        experiment=None,
         worker=OmegaConf.structured(WorkerConf()),
         algorithm=OmegaConf.structured(AlgorithmConf()),
         storage=OmegaConf.structured(StorageConf()),

--- a/tests/test_orion_sweeper_plugin.py
+++ b/tests/test_orion_sweeper_plugin.py
@@ -231,7 +231,7 @@ def test_orion_example(
 
     assert isinstance(returns, DictConfig)
     assert returns.name == "orion"
-    assert len(returns) == 8
+    assert len(returns) == 15
 
     best_parameters = returns.best_evaluated_params
     assert not best_parameters.dropout.is_integer()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -12,7 +12,6 @@ choices_formats = [[4, 6, 8], ["a", "b", "c", "d"], dict(a=0.25, b=0.75)]
 
 @pytest.mark.parametrize("options", choices_formats)
 def test_choices(options):
-
     dim = choices(options)("dimname")
 
     assert dim.get_prior_string() == f"choices({options})"

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -13,7 +13,6 @@ from hydra_plugins.hydra_orion_sweeper.orion_sweeper import (
 def test_parametrization_is_deprecated():
     with pytest.warns(DeprecationWarning) as warnings:
         OrionSweeper(
-            None,
             OrionClientConf(),
             WorkerConf(),
             AlgorithmConf(),
@@ -33,7 +32,6 @@ def test_parametrization_is_deprecated():
 def test_parametrization_and_params():
     with pytest.warns(DeprecationWarning) as warnings:
         OrionSweeper(
-            None,
             OrionClientConf(),
             WorkerConf(),
             AlgorithmConf(),
@@ -52,7 +50,6 @@ def test_parametrization_and_params():
 
 def test_no_warnings_with_params(recwarn):
     OrionSweeper(
-        None,
         OrionClientConf(),
         WorkerConf(),
         AlgorithmConf(),
@@ -65,53 +62,3 @@ def test_no_warnings_with_params(recwarn):
 
 
 # <<< Remove with Issue #8
-
-
-def test_sweeper_orion_is_deprecated():
-    with pytest.warns(DeprecationWarning) as warnings:
-        OrionSweeper(
-            OrionClientConf(),
-            OrionClientConf(),
-            WorkerConf(),
-            AlgorithmConf(),
-            StorageConf(),
-            None,
-            dict(),
-        )
-
-    assert len(warnings) == 1
-    assert (
-        warnings[0].message.args[0].startswith("`hydra.sweeper.orion` is deprecated;")
-    )
-
-
-def test_sweeper_orion_is_deprecated_2():
-    with pytest.warns(DeprecationWarning) as warnings:
-        OrionSweeper(
-            OrionClientConf(),
-            None,
-            WorkerConf(),
-            AlgorithmConf(),
-            StorageConf(),
-            None,
-            dict(),
-        )
-
-    assert len(warnings) == 1
-    assert (
-        warnings[0].message.args[0].startswith("`hydra.sweeper.orion` is deprecated;")
-    )
-
-
-def test_no_warnings_with_experiment(recwarn):
-    OrionSweeper(
-        None,
-        OrionClientConf(),
-        WorkerConf(),
-        AlgorithmConf(),
-        StorageConf(),
-        None,
-        dict(),
-    )
-
-    assert len(recwarn) == 0

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -13,6 +13,7 @@ from hydra_plugins.hydra_orion_sweeper.orion_sweeper import (
 def test_parametrization_is_deprecated():
     with pytest.warns(DeprecationWarning) as warnings:
         OrionSweeper(
+            None,
             OrionClientConf(),
             WorkerConf(),
             AlgorithmConf(),
@@ -25,13 +26,14 @@ def test_parametrization_is_deprecated():
     assert (
         warnings[0]
         .message.args[0]
-        .startswith("`hydra.sweeper.orion.parametrization` is deprecated;")
+        .startswith("`hydra.sweeper.parametrization` is deprecated;")
     )
 
 
 def test_parametrization_and_params():
     with pytest.warns(DeprecationWarning) as warnings:
         OrionSweeper(
+            None,
             OrionClientConf(),
             WorkerConf(),
             AlgorithmConf(),
@@ -44,12 +46,13 @@ def test_parametrization_and_params():
     assert (
         warnings[0]
         .message.args[0]
-        .startswith("Both `hydra.sweeper.orion.parametrization` and")
+        .startswith("Both `hydra.sweeper.parametrization` and")
     )
 
 
 def test_no_warnings_with_params(recwarn):
     OrionSweeper(
+        None,
         OrionClientConf(),
         WorkerConf(),
         AlgorithmConf(),
@@ -62,3 +65,53 @@ def test_no_warnings_with_params(recwarn):
 
 
 # <<< Remove with Issue #8
+
+
+def test_sweeper_orion_is_deprecated():
+    with pytest.warns(DeprecationWarning) as warnings:
+        OrionSweeper(
+            OrionClientConf(),
+            OrionClientConf(),
+            WorkerConf(),
+            AlgorithmConf(),
+            StorageConf(),
+            None,
+            dict(),
+        )
+
+    assert len(warnings) == 1
+    assert (
+        warnings[0].message.args[0].startswith("`hydra.sweeper.orion` is deprecated;")
+    )
+
+
+def test_sweeper_orion_is_deprecated_2():
+    with pytest.warns(DeprecationWarning) as warnings:
+        OrionSweeper(
+            OrionClientConf(),
+            None,
+            WorkerConf(),
+            AlgorithmConf(),
+            StorageConf(),
+            None,
+            dict(),
+        )
+
+    assert len(warnings) == 1
+    assert (
+        warnings[0].message.args[0].startswith("`hydra.sweeper.orion` is deprecated;")
+    )
+
+
+def test_no_warnings_with_experiment(recwarn):
+    OrionSweeper(
+        None,
+        OrionClientConf(),
+        WorkerConf(),
+        AlgorithmConf(),
+        StorageConf(),
+        None,
+        dict(),
+    )
+
+    assert len(recwarn) == 0


### PR DESCRIPTION
Hydra relaxed omegaconf pinned version which broke the hydra_orion_sweeper.
It seems omegaconf later versions is confused about `hydra.sweeper.orion` configuration key which (I guess) might be clashing with the orion sweeper.

As a result we are now pinning the omegaconf configuration.
we created a new experiment key that will replace the orion key in next release
We added warnings if the orion configuration is used.
