### PR TITLE
Adding README warning PBT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ algorithms for the optimization of the parameters of any experiment.
 
 See `website <https://orion.readthedocs.io>`_ for more information
 
+**Warning: PBT-style algorithms are not currently supported by this plugin.**
 
 Install
 -------


### PR DESCRIPTION
Not currently possible to resume `pbt`-like algorithm trials. Adding a warning to decentivize trying it until fixed.

See https://github.com/Epistimio/hydra_orion_sweeper/issues/20#issuecomment-1939604757.